### PR TITLE
Added tags variable for optional tags on EC2 and EBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ No modules.
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile - IAM Role to allow SSM | `string` | `""` | no |
 | <a name="input_publisher_name"></a> [publisher\_name](#input\_publisher\_name) | Publisher Name | `string` | n/a | yes |
 | <a name="input_use_ssm"></a> [use\_ssm](#input\_use\_ssm) | Use SSM to Register Publisher - Use if http\_tokens set to required - Must include IAM Instance Profile if used | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Optional additional tags to apply to the EC2 instance and attached EBS volume | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -31,13 +31,25 @@ resource "aws_instance" "NPAPublisher" {
   monitoring                  = var.aws_monitoring
   ebs_optimized               = var.ebs_optimized
 
-  tags = {
-    "Name" = var.publisher_name
-  }
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.publisher_name
+    }
+  )
   
   metadata_options {
     http_endpoint               = var.http_endpoint
     http_tokens                 = var.http_tokens
+  }
+
+  root_block_device {
+    tags = merge(
+      var.tags,
+      {
+        "Name" = var.publisher_name
+      }
+    )
   }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,9 @@ variable "use_ssm" {
   type        = bool
   default     = false
 }
+
+variable "tags" {
+  description = "Additonal tags to apply to the EC2 instance"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This PR is to address https://github.com/netskopeoss/terraform-netskope-publisher-aws/issues/2 

Optional tags variable to add additional tags to EC2 instance and the attached EBS volume. Additional tags are often required in an enterprise deployment.