### PR TITLE
Update module for 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ module "publisher-aws" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.14.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
-| <a name="requirement_netskope"></a> [netskope](#requirement\_netskope) | ~> 0.3.2 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.13.1 |
+| <a name="requirement_netskope"></a> [netskope](#requirement\_netskope) | ~> 0.3.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.13.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
-| <a name="provider_netskope"></a> [netskope](#provider\_netskope) | ~> 0.3.2 |
-| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.13.1 |
+| <a name="provider_netskope"></a> [netskope](#provider\_netskope) | ~> 0.3.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.13.0 |
 
 ## Modules
 
@@ -128,6 +128,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_ec2_instance_id"></a> [ec2\_instance\_id](#output\_ec2\_instance\_id) | ID of the EC2 Instance used for the Publisher |
 | <a name="output_publisher_id"></a> [publisher\_id](#output\_publisher\_id) | ID of the Publisher |
 | <a name="output_publisher_name"></a> [publisher\_name](#output\_publisher\_name) | Name of the Publisher |
+| <a name="output_publisher_private_ip"></a> [publisher\_private\_ip](#output\_publisher\_private\_ip) | Private IP of the Publisher |
+| <a name="output_publisher_public_ip"></a> [publisher\_public\_ip](#output\_publisher\_public\_ip) | Public IP of the Publisher |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -73,16 +73,18 @@ module "publisher-aws" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_netskope"></a> [netskope](#requirement\_netskope) | 0.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.14.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| <a name="requirement_netskope"></a> [netskope](#requirement\_netskope) | ~> 0.3.2 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.13.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_netskope"></a> [netskope](#provider\_netskope) | 0.2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_netskope"></a> [netskope](#provider\_netskope) | ~> 0.3.2 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.13.1 |
 
 ## Modules
 
@@ -92,10 +94,16 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_instance_profile.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.NPAPublisher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_ssm_association.register_publishers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_association) | resource |
 | [aws_ssm_document.PublisherRegistration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document) | resource |
-| netskope_publishers.Publisher | resource |
+| [netskope_npa_publisher.Publisher](https://registry.terraform.io/providers/netskopeoss/netskope/latest/docs/resources/npa_publisher) | resource |
+| [netskope_npa_publisher_token.Publisher](https://registry.terraform.io/providers/netskopeoss/netskope/latest/docs/resources/npa_publisher_token) | resource |
+| [time_rotating.Publisher_token](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
+| [time_static.rotate](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
 | [aws_ami.npa-publisher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 
 ## Inputs
@@ -111,19 +119,15 @@ No modules.
 | <a name="input_aws_subnet"></a> [aws\_subnet](#input\_aws\_subnet) | AWS Subnet Id | `string` | n/a | yes |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | Enable EBS Optimized | `bool` | `true` | no |
 | <a name="input_http_endpoint"></a> [http\_endpoint](#input\_http\_endpoint) | Metadata Service enabled or disabled | `string` | `"enabled"` | no |
-| <a name="input_http_tokens"></a> [http\_tokens](#input\_http\_tokens) | Metadata Service V2 optional or reuqired - Use SSM set to required | `string` | `"optional"` | no |
-| <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile - IAM Role to allow SSM | `string` | `""` | no |
+| <a name="input_http_tokens"></a> [http\_tokens](#input\_http\_tokens) | Metadata Service V2 optional or reuqired - Use SSM set to required | `string` | `"required"` | no |
+| <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile name to attach to the EC2 instance. When use\_ssm is true and this is left null, an IAM role with the AmazonSSMManagedInstanceCore policy and a matching instance profile are created automatically. | `string` | `null` | no |
 | <a name="input_publisher_name"></a> [publisher\_name](#input\_publisher\_name) | Publisher Name | `string` | n/a | yes |
-| <a name="input_use_ssm"></a> [use\_ssm](#input\_use\_ssm) | Use SSM to Register Publisher - Use if http\_tokens set to required - Must include IAM Instance Profile if used | `bool` | `false` | no |
+| <a name="input_use_ssm"></a> [use\_ssm](#input\_use\_ssm) | Use SSM to register the Publisher instead of passing the token via user\_data. Recommended when http\_tokens is set to required (IMDSv2). When enabled without an iam\_instance\_profile, an IAM role and instance profile with AmazonSSMManagedInstanceCore are created automatically. | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_ec2_instance_id"></a> [ec2\_instance\_id](#output\_ec2\_instance\_id) | ID of the EC2 Instance used for the Publisher |
 | <a name="output_publisher_id"></a> [publisher\_id](#output\_publisher\_id) | ID of the Publisher |
 | <a name="output_publisher_name"></a> [publisher\_name](#output\_publisher\_name) | Name of the Publisher |
-| <a name="output_publisher_private_ip"></a> [publisher\_private\_ip](#output\_publisher\_private\_ip) | Private IP of the Publisher |
-| <a name="output_publisher_public_ip"></a> [publisher\_public\_ip](#output\_publisher\_public\_ip) | Public IP of the Publisher |
-| <a name="output_publisher_token"></a> [publisher\_token](#output\_publisher\_token) | Public IP of the Publisher |
 <!-- END_TF_DOCS -->

--- a/instance-profile.tf
+++ b/instance-profile.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_role" "ssm" {
+  count = var.use_ssm && var.iam_instance_profile == null ? 1 : 0
+  name  = var.publisher_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  count      = var.use_ssm && var.iam_instance_profile == null ? 1 : 0
+  role       = aws_iam_role.ssm[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ssm" {
+  count = var.use_ssm && var.iam_instance_profile == null ? 1 : 0
+  name  = var.publisher_name
+  role  = aws_iam_role.ssm[0].name
+}

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,10 @@ resource "netskope_npa_publisher" "Publisher" {
   publisher_name = var.publisher_name
 }
 
+resource "netskope_npa_publisher_token" "Publisher" {
+  publisher_id = netskope_npa_publisher.Publisher.publisher_id 
+}
+
 //AWS Data
 //
 // Filter Netskope Publishers AMIs for the latests version
@@ -27,7 +31,7 @@ resource "aws_instance" "NPAPublisher" {
   key_name                    = var.aws_key_name
   subnet_id                   = var.aws_subnet
   vpc_security_group_ids      = [var.aws_security_group]
-  user_data                   = "${var.use_ssm == true ? "" : netskope_npa_publisher.Publisher.token}" 
+  user_data                   = "${var.use_ssm == true ? "" : netskope_npa_publisher_token}" 
   monitoring                  = var.aws_monitoring
   ebs_optimized               = var.ebs_optimized
 
@@ -61,7 +65,7 @@ resource "aws_ssm_document" "PublisherRegistration" {
         "properties": [
           {
             "id": "0.aws:runShellScript",
-            "runCommand": ["sudo /home/ubuntu/npa_publisher_wizard -token \"${netskope_npa_publisher.Publisher.token}\""] 
+            "runCommand": ["sudo /home/ubuntu/npa_publisher_wizard -token \"${netskope_npa_publisher_token}\""] 
           }
         ]
       }

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_ami" "npa-publisher" {
 
 // Create EC2 Instance for the Publisher
 resource "aws_instance" "NPAPublisher" {
-  ami = var.ami_id
+  ami = var.ami_id != "" ? var.ami_id : "${data.aws_ami.npa-publisher.id}"
   associate_public_ip_address = var.associate_public_ip_address
   iam_instance_profile        = var.iam_instance_profile
   instance_type               = var.aws_instance_type

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,9 @@ resource "aws_ssm_document" "PublisherRegistration" {
   count = "${var.use_ssm == true ? 1 : 0}"
   name          = "SSM-Register-${var.publisher_name}"
   document_type = "Command"
-
+  lifecycle {
+    create_before_destroy = true
+  }
   content = <<DOC
   {
     "schemaVersion": "1.2",

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_ami" "npa-publisher" {
 
 // Create EC2 Instance for the Publisher
 resource "aws_instance" "NPAPublisher" {
-  ami                         = var.ami_id != "" ? var.ami_id : "${data.aws_ami.npa-publisher.id}"
+  ami = var.ami_id
   associate_public_ip_address = var.associate_public_ip_address
   iam_instance_profile        = var.iam_instance_profile
   instance_type               = var.aws_instance_type

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "NPAPublisher" {
   key_name                    = var.aws_key_name
   subnet_id                   = var.aws_subnet
   vpc_security_group_ids      = [var.aws_security_group]
-  user_data                   = "${var.use_ssm == true ? "" : netskope_npa_publisher_token}" 
+  user_data                   = "${var.use_ssm == true ? "" : netskope_npa_publisher_token.Publisher.token}" 
   monitoring                  = var.aws_monitoring
   ebs_optimized               = var.ebs_optimized
 
@@ -65,7 +65,7 @@ resource "aws_ssm_document" "PublisherRegistration" {
         "properties": [
           {
             "id": "0.aws:runShellScript",
-            "runCommand": ["sudo /home/ubuntu/npa_publisher_wizard -token \"${netskope_npa_publisher_token}\""] 
+            "runCommand": ["sudo /home/ubuntu/npa_publisher_wizard -token \"${netskope_npa_publisher_token.Publisher.token}\""] 
           }
         ]
       }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 //
 //Create Publisher in Netskope
 resource "netskope_npa_publisher" "Publisher" {
-  name = var.publisher_name
+  publisher_name = var.publisher_name
 }
 
 //AWS Data

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,9 @@ DOC
 resource "aws_ssm_association" "register_publishers" {
   count = "${var.use_ssm == true ? 1 : 0}"
   name = "SSM-Register-${var.publisher_name}"
-  
+  lifecycle {
+    create_before_destroy = true
+  }
   targets {
     key    = "InstanceIds"
     values = [aws_instance.NPAPublisher.id]

--- a/main.tf
+++ b/main.tf
@@ -11,17 +11,10 @@ resource "netskope_npa_publisher_token" "Publisher" {
   
   lifecycle {
     replace_triggered_by = [
-      null_resource.always_refresh.id
+      data.aws_ami.npa-publisher.id
     ]
   }
 }
-
-resource "null_resource" "always_refresh" {
-  triggers = {
-    refresh = timestamp()
-  }
-}
-
 
 
 //AWS Data

--- a/main.tf
+++ b/main.tf
@@ -8,14 +8,18 @@ resource "netskope_npa_publisher" "Publisher" {
 
 resource "netskope_npa_publisher_token" "Publisher" {
   publisher_id = netskope_npa_publisher.Publisher.publisher_id 
-  
   lifecycle {
     replace_triggered_by = [
-      data.aws_ami.npa-publisher.id
+      null_resource.ami_change.id
     ]
   }
 }
 
+resource "null_resource" "ami_change" {
+  triggers = {
+    ami_id = data.aws_ami.npa-publisher.id
+  }
+}
 
 //AWS Data
 //

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 //Netskope Resources
 //
 //Create Publisher in Netskope
-resource "netskope_publishers" "Publisher" {
+resource "netskope_npa_publisher" "Publisher" {
   name = var.publisher_name
 }
 
@@ -27,7 +27,7 @@ resource "aws_instance" "NPAPublisher" {
   key_name                    = var.aws_key_name
   subnet_id                   = var.aws_subnet
   vpc_security_group_ids      = [var.aws_security_group]
-  user_data                   = "${var.use_ssm == true ? "" : netskope_publishers.Publisher.token}" 
+  user_data                   = "${var.use_ssm == true ? "" : netskope_npa_publisher.Publisher.token}" 
   monitoring                  = var.aws_monitoring
   ebs_optimized               = var.ebs_optimized
 
@@ -61,7 +61,7 @@ resource "aws_ssm_document" "PublisherRegistration" {
         "properties": [
           {
             "id": "0.aws:runShellScript",
-            "runCommand": ["sudo /home/ubuntu/npa_publisher_wizard -token \"${netskope_publishers.Publisher.token}\""] 
+            "runCommand": ["sudo /home/ubuntu/npa_publisher_wizard -token \"${netskope_npa_publisher.Publisher.token}\""] 
           }
         ]
       }

--- a/main.tf
+++ b/main.tf
@@ -5,9 +5,24 @@ resource "netskope_npa_publisher" "Publisher" {
   publisher_name = var.publisher_name
 }
 
+
 resource "netskope_npa_publisher_token" "Publisher" {
   publisher_id = netskope_npa_publisher.Publisher.publisher_id 
+  
+  lifecycle {
+    replace_triggered_by = [
+      null_resource.always_refresh.id
+    ]
+  }
 }
+
+resource "null_resource" "always_refresh" {
+  triggers = {
+    refresh = timestamp()
+  }
+}
+
+
 
 //AWS Data
 //

--- a/main.tf
+++ b/main.tf
@@ -1,29 +1,33 @@
-//Netskope Resources
-//
-//Create Publisher in Netskope
+# Netskope Resources
+
+# Create Publisher in Netskope
 resource "netskope_npa_publisher" "Publisher" {
   publisher_name = var.publisher_name
 }
 
+# Forces the token to be recreated each apply
+# Avoids spinning up new publisher instances with invalid tokens
+resource "time_rotating" "Publisher_token" {
+  rotation_minutes = 1
+}
+
+resource "time_static" "rotate" {
+  rfc3339 = time_rotating.Publisher_token.rfc3339
+}
 
 resource "netskope_npa_publisher_token" "Publisher" {
-  publisher_id = netskope_npa_publisher.Publisher.publisher_id 
+  depends_on   = [time_rotating.Publisher_token]
+  publisher_id = netskope_npa_publisher.Publisher.publisher_id
   lifecycle {
     replace_triggered_by = [
-      null_resource.ami_change.id
+      time_static.rotate
     ]
   }
 }
 
-resource "null_resource" "ami_change" {
-  triggers = {
-    ami_id = data.aws_ami.npa-publisher.id
-  }
-}
+# AWS Data
 
-//AWS Data
-//
-// Filter Netskope Publishers AMIs for the latests version
+# Filter Netskope Publishers AMIs for the latest version
 data "aws_ami" "npa-publisher" {
   most_recent = true
   owners      = ["679593333241"]
@@ -34,78 +38,64 @@ data "aws_ami" "npa-publisher" {
   }
 }
 
-// Create EC2 Instance for the Publisher
+# Create EC2 Instance for the Publisher
 resource "aws_instance" "NPAPublisher" {
-  ami = var.ami_id != "" ? var.ami_id : "${data.aws_ami.npa-publisher.id}"
+  ami                         = var.ami_id != "" ? var.ami_id : data.aws_ami.npa-publisher.id
   associate_public_ip_address = var.associate_public_ip_address
-  iam_instance_profile        = var.iam_instance_profile
+  iam_instance_profile        = var.iam_instance_profile != null ? var.iam_instance_profile : (var.use_ssm ? aws_iam_instance_profile.ssm[0].name : null)
   instance_type               = var.aws_instance_type
   key_name                    = var.aws_key_name
   subnet_id                   = var.aws_subnet
   vpc_security_group_ids      = [var.aws_security_group]
-  user_data                   = "${var.use_ssm == true ? "" : netskope_npa_publisher_token.Publisher.token}" 
+  user_data_base64            = var.use_ssm == true ? null : netskope_npa_publisher_token.Publisher.token
   monitoring                  = var.aws_monitoring
   ebs_optimized               = var.ebs_optimized
-
+  root_block_device {
+    encrypted   = true
+    volume_type = "gp3"
+  }
   tags = {
     "Name" = var.publisher_name
   }
-  
+
   metadata_options {
-    http_endpoint               = var.http_endpoint
-    http_tokens                 = var.http_tokens
+    http_endpoint = var.http_endpoint
+    http_tokens   = var.http_tokens
   }
-
-
 }
 
-
-//Create SSM Document for Publisher with versioning
+# Create SSM Document for Publisher with versioning
 resource "aws_ssm_document" "PublisherRegistration" {
-  count = var.use_ssm == true ? 1 : 0
+  count         = var.use_ssm == true ? 1 : 0
   name          = "SSM-Register-${var.publisher_name}"
   document_type = "Command"
-  
+
   content = jsonencode({
-    schemaVersion = "1.2"
+    schemaVersion = "2.2"
     description   = "Register a Netskope Publisher via SSM"
     parameters    = {}
-    runtimeConfig = {
-      "aws:runShellScript" = {
-        properties = [
-          {
-            id         = "0.aws:runShellScript"
-            runCommand = ["sudo /home/ubuntu/npa_publisher_wizard -token \"${netskope_npa_publisher_token.Publisher.token}\""]
-          }
-        ]
+    mainSteps = [
+      {
+        action = "aws:runShellScript"
+        name   = "registerPublisher"
+        inputs = {
+          runCommand = ["sudo /home/ubuntu/npa_publisher_wizard -token \"${netskope_npa_publisher_token.Publisher.token}\""]
+        }
       }
-    }
+    ]
   })
 
   document_format = "JSON"
-  
-  # Create new version when content changes
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
-//Associate Publisher with SSM
+# Associate Publisher with SSM
 resource "aws_ssm_association" "register_publishers" {
-  count = var.use_ssm == true ? 1 : 0
-  name              = aws_ssm_document.PublisherRegistration[0].name
-  association_name  = "Register-${var.publisher_name}"
-  
+  count            = var.use_ssm == true ? 1 : 0
+  name             = aws_ssm_document.PublisherRegistration[0].name
+  association_name = "Register-${var.publisher_name}"
+
   targets {
     key    = "InstanceIds"
     values = [aws_instance.NPAPublisher.id]
   }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-  
-  depends_on = [aws_ssm_document.PublisherRegistration]
 }
-
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,13 @@
 //Publisher Details
-# output "publisher_name" {
-#   description = "Name of the Publisher"
-#   value       = netskope_npa_publisher.Publisher.common_name
-# }
+output "publisher_name" {
+  description = "Name of the Publisher"
+  value       = netskope_npa_publisher.Publisher.common_name
+}
 
-# output "publisher_id" {
-#   description = "ID of the Publisher"
-#   value       = netskope_npa_publisher.Publisher.publisher_id
-# }
+output "publisher_id" {
+  description = "ID of the Publisher"
+  value       = netskope_npa_publisher.Publisher.publisher_id
+}
 
 # output "publisher_public_ip" {
 #   description = "Public IP of the Publisher"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,30 +1,30 @@
 //Publisher Details
-output "publisher_name" {
-  description = "Name of the Publisher"
-  value       = netskope_publishers.Publisher.name
-}
+# output "publisher_name" {
+#   description = "Name of the Publisher"
+#   value       = netskope_npa_publisher.Publisher.common_name
+# }
 
-output "publisher_id" {
-  description = "ID of the Publisher"
-  value       = netskope_publishers.Publisher.id
-}
+# output "publisher_id" {
+#   description = "ID of the Publisher"
+#   value       = netskope_npa_publisher.Publisher.publisher_id
+# }
 
-output "publisher_public_ip" {
-  description = "Public IP of the Publisher"
-  value       = aws_instance.NPAPublisher.public_ip
-}
+# output "publisher_public_ip" {
+#   description = "Public IP of the Publisher"
+#   value       = aws_instance.NPAPublisher.public_ip
+# }
 
-output "publisher_private_ip" {
-  description = "Private IP of the Publisher"
-  value       = aws_instance.NPAPublisher.private_ip
-}
+# output "publisher_private_ip" {
+#   description = "Private IP of the Publisher"
+#   value       = aws_instance.NPAPublisher.private_ip
+# }
 
-output "publisher_token" {
-  description = "Public IP of the Publisher"
-  value       = netskope_publishers.Publisher.token
-}
+# output "publisher_token" {
+#   description = "Public IP of the Publisher"
+#   value       = netskope_publishers.Publisher.token
+# }
 
-output "ec2_instance_id" {
-  description = "ID of the EC2 Instance used for the Publisher"
-  value       = aws_instance.NPAPublisher.id
-}
+# output "ec2_instance_id" {
+#   description = "ID of the EC2 Instance used for the Publisher"
+#   value       = aws_instance.NPAPublisher.id
+# }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,3 +8,18 @@ output "publisher_id" {
   description = "ID of the Publisher"
   value       = netskope_npa_publisher.Publisher.publisher_id
 }
+
+output "publisher_public_ip" {
+  description = "Public IP of the Publisher"
+  value       = aws_instance.NPAPublisher.public_ip
+}
+
+output "publisher_private_ip" {
+  description = "Private IP of the Publisher"
+  value       = aws_instance.NPAPublisher.private_ip
+}
+
+output "ec2_instance_id" {
+  description = "ID of the EC2 Instance used for the Publisher"
+  value       = aws_instance.NPAPublisher.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-//Publisher Details
+# Publisher Details
 output "publisher_name" {
   description = "Name of the Publisher"
   value       = netskope_npa_publisher.Publisher.common_name
@@ -8,23 +8,3 @@ output "publisher_id" {
   description = "ID of the Publisher"
   value       = netskope_npa_publisher.Publisher.publisher_id
 }
-
-# output "publisher_public_ip" {
-#   description = "Public IP of the Publisher"
-#   value       = aws_instance.NPAPublisher.public_ip
-# }
-
-# output "publisher_private_ip" {
-#   description = "Private IP of the Publisher"
-#   value       = aws_instance.NPAPublisher.private_ip
-# }
-
-# output "publisher_token" {
-#   description = "Public IP of the Publisher"
-#   value       = netskope_publishers.Publisher.token
-# }
-
-# output "ec2_instance_id" {
-#   description = "ID of the EC2 Instance used for the Publisher"
-#   value       = aws_instance.NPAPublisher.id
-# }

--- a/variables.tf
+++ b/variables.tf
@@ -49,8 +49,8 @@ variable "ami_id" {
 }
 
 variable "iam_instance_profile" {
-  description = "IAM Instance Profile - IAM Role to allow SSM"
-  default     = ""
+  description = "IAM Instance Profile name to attach to the EC2 instance. When use_ssm is true and this is left null, an IAM role with the AmazonSSMManagedInstanceCore policy and a matching instance profile are created automatically."
+  default     = null
   type        = string
 }
 
@@ -63,11 +63,11 @@ variable "http_endpoint" {
 variable "http_tokens" {
   description = "Metadata Service V2 optional or reuqired - Use SSM set to required"
   type        = string
-  default     = "optional"
+  default     = "required"
 }
 
 variable "use_ssm" {
-  description = "Use SSM to Register Publisher - Use if http_tokens set to required - Must include IAM Instance Profile if used"
+  description = "Use SSM to register the Publisher instead of passing the token via user_data. Recommended when http_tokens is set to required (IMDSv2). When enabled without an iam_instance_profile, an IAM role and instance profile with AmazonSSMManagedInstanceCore are created automatically."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/version.tf
+++ b/version.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.0"
     }
   }
   required_version = ">= 1.1.7"

--- a/version.tf
+++ b/version.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     netskope = {
-      version = ">= 0.2.1"
+      version = ">= 0.3.2"
       source  = "netskopeoss/netskope"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = "~>5.0"
     }
   }
   required_version = ">= 1.1.7"

--- a/version.tf
+++ b/version.tf
@@ -1,13 +1,17 @@
 terraform {
   required_providers {
     netskope = {
-      version = ">= 0.3.2"
+      version = "~> 0.3.2"
       source  = "netskopeoss/netskope"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~>5.0"
+      version = "~> 6.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13.1"
     }
   }
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.14.0"
 }

--- a/version.tf
+++ b/version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     netskope = {
-      version = "~> 0.3.2"
+      version = "~> 0.3.0"
       source  = "netskopeoss/netskope"
     }
     aws = {
@@ -10,7 +10,7 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.13.1"
+      version = "~> 0.13.0"
     }
   }
   required_version = ">= 1.14.0"


### PR DESCRIPTION
This module seems to have been left for some time. I took the version maintained by @jayolmos (https://github.com/miraiadvisory/terraform-netskope-publisher-aws) and more widely updated it for our purposes here. This included changing a number of defaults and adding creation of an IAM Instance Profile with access to SSM, so if this is ever merged it should probably be a new major version.

Happy to take any comments.

@jharris-ns as maintainer of the provider maybe you could review this?

